### PR TITLE
Pea/disable rsvp

### DIFF
--- a/src/App/Admin/Options.php
+++ b/src/App/Admin/Options.php
@@ -159,13 +159,13 @@ class Options extends Base {
 			self::OPTIONS_NAME,
 			self::OPTIONS_NAME . '_section'
 		);
-		\add_settings_field(
-			'rsvp_form',
-			__( 'RSVP Form', 'dc-events-manager' ),
-			array( $this, 'renderSelectRSVPForm' ),
-			self::OPTIONS_NAME,
-			self::OPTIONS_NAME . '_section'
-		);
+		// \add_settings_field(
+		// 	'rsvp_form',
+		// 	__( 'RSVP Form', 'dc-events-manager' ),
+		// 	array( $this, 'renderSelectRSVPForm' ),
+		// 	self::OPTIONS_NAME,
+		// 	self::OPTIONS_NAME . '_section'
+		// );
 		\add_settings_field(
 			'hide_canceled',
 			__( 'Hide Canceled Events', 'dc-events-manager' ),

--- a/src/App/Integration/ContactForm7.php
+++ b/src/App/Integration/ContactForm7.php
@@ -85,7 +85,7 @@ class ContactForm7 extends Base {
 		if ( isset( $this->endpoint ) && $this->rsvp_form && ! empty( $this->endpoint ) && ! empty( $this->rsvp_form ) ) {
 
 			\add_action( 'admin_init', array( $this, 'set_options' ) );
-			\add_action( 'acf/init', array( $this, 'register_fields' ) );
+			// \add_action( 'acf/init', array( $this, 'register_fields' ) );
 
 			\add_action( 'wpcf7_before_send_mail', array( $this, 'send_data' ), 10, 3 );
 			\add_filter( 'shortcode_atts_wpcf7', array( $this, 'add_atts' ), 10, 3 );

--- a/src/App/Integration/ContactForm7.php
+++ b/src/App/Integration/ContactForm7.php
@@ -173,7 +173,7 @@ class ContactForm7 extends Base {
 							'id'    => '',
 						),
 						'message'           => \__( 'Display RSVP form on single event page', 'site-functionality' ),
-						'default_value'     => 1,
+						'default_value'     => 0,
 						'ui'                => 1,
 						'ui_on_text'        => '',
 						'ui_off_text'       => '',

--- a/src/App/Integration/EM_Events.php
+++ b/src/App/Integration/EM_Events.php
@@ -135,7 +135,7 @@ class EM_Events extends Base {
 		 * @see Bootstrap::__construct
 		 */
 		if ( isset( $this->endpoint ) || ! empty( $this->endpoint ) ) {
-			\add_action( 'save_post_event', array( $this, 'save_data' ), 10, 3 );
+			\add_action( 'save_post', array( $this, 'save_data' ), 10, 3 );
 			\add_action( 'post_updated', array( $this, 'update_data' ), 10, 3 );
 		}
 		// Run late - after add_action('save_post',array('EM_Event_Recurring_Post_Admin','save_post'),10000,1);
@@ -170,7 +170,7 @@ class EM_Events extends Base {
 			return;
 		}
 
-		if ( $EM_Event = $this->parse_data( $post_id ) ) {
+		if ( 'event' === $post->post_type && $EM_Event = $this->parse_data( $post_id ) ) {
 			$response = ( new Webhooks( $this->version, $this->plugin_name ) )->call( $this->endpoint, $EM_Event );
 			// error_log( __METHOD__ . ': ' . json_encode( $response ) );
 		}

--- a/src/App/Integration/EM_Events.php
+++ b/src/App/Integration/EM_Events.php
@@ -144,6 +144,8 @@ class EM_Events extends Base {
 
 	/**
 	 * Resave recurring event to fix date/time sent to Zoom
+	 * 
+	 * @uses https://developer.wordpress.org/reference/functions/add_post_meta/
 	 *
 	 * @param integer $post_ID
 	 * @param \WP_Post $post
@@ -154,7 +156,7 @@ class EM_Events extends Base {
 		if ( $update || \wp_is_post_revision( $post_id ) || 'event-recurring' !== $post->post_type ) {
 			return;
 		}
-		\update_post_meta( $post_id, 'resaved_recurring', date( 'c' ) );
+		\add_post_meta( $post_id, 'resaved_recurring', date( 'c' ), true );
 	}
 
 	/**


### PR DESCRIPTION
- [Disable enable_rsvp field on event admin](https://github.com/debtcollective/dc-events-manager/commit/4eb2a15e33aeba3ff22279b1729c41953820c27a)
- [Disable RSVP form selection field from DC Settings page](https://github.com/debtcollective/dc-events-manager/commit/c9694ad1a2138f29c34f492644e1eb630922c6f8)
- [Hook save_data to save_post action](https://github.com/debtcollective/dc-events-manager/commit/0046827161c70fea312791cf6fac31cf2ded3f5f)
   - See comment: https://developer.wordpress.org/reference/hooks/save_post/#comment-5519
- [Use add_post_meta with $unique option](https://github.com/debtcollective/dc-events-manager/commit/2ab41af3e6ffce3f074eed5a0f502928b975562a)
   - Prevent meta from being repeatedly added.